### PR TITLE
fix: remove model claim from generation

### DIFF
--- a/src/odin/odin/client/generate.py
+++ b/src/odin/odin/client/generate.py
@@ -78,7 +78,6 @@ def main():
         "--odin-image", "--odin_image", help="The name of the image to use for odin exporting and odin chores."
     )
     parser.add_argument("--claim-name", "--claim_name", help="The name of the k8s pvc claim.")
-    parser.add_argument('--models-claim', "--models_claim", help="/models pvc name")
     parser.add_argument(
         "--pull-policy",
         "--pull_policy",


### PR DESCRIPTION
This was an internal thing we used to do. This was partially removed
from the client code but not from the server code. This PR totally
removes it. We didn't catch it because we don't use odin-generate much
and are moving towards getting rid of it AFAIK