### PR TITLE
remove k8s client dep

### DIFF
--- a/src/odin-api/setup.cfg
+++ b/src/odin-api/setup.cfg
@@ -50,7 +50,6 @@ install_requires =
     websockets
     requests
     requests-async
-    kubernetes
     pyyaml >= 5.1
     prompt_toolkit >= 2.0.0
 


### PR DESCRIPTION
we dont need kubernetes anymore as we can get the logs from the odin API