### PR TITLE
limit the mongo version for now

### DIFF
--- a/src/odin/setup.py
+++ b/src/odin/setup.py
@@ -30,7 +30,7 @@ setup(
         'kubernetes',
         'shortid',
         'GitPython',
-        'pymongo',
+        'pymongo <= 3.12.0',
         'SQLAlchemy',
         'psycopg2-binary',
         'ruamel.yaml',


### PR DESCRIPTION
using a standard albeit old version of mongo
the new pypi package complains about the wire
protocol being too low