### PR TITLE
Chore/ws health

### DIFF
--- a/src/odin-api/muninn/client/ping.py
+++ b/src/odin-api/muninn/client/ping.py
@@ -5,24 +5,37 @@ import asyncio
 from datetime import datetime
 import json
 import websockets
-from muninn import ODIN_URL, ODIN_PORT, ODIN_SCHEME, ODIN_API_LOGGER, APIField, APIStatus
+from muninn import ODIN_URL, ODIN_PORT, ODIN_SCHEME, HttpClient, ODIN_API_LOGGER, APIField, APIStatus
 
 
-async def ping(uri: str, message: str) -> None:
+async def ping(uri: str) -> None:
     """Ping odin at uri and send message.
 
     :param uri: The location of the server
-    :param message: The message you expect to see back
     :raises RuntimeError: If the server returns an error
     """
     async with websockets.connect(uri) as websocket:
+        message = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
         await websocket.send(json.dumps({APIField.COMMAND: 'PING', APIField.REQUEST: message}))
         resp = json.loads(await websocket.recv())
         if resp[APIField.STATUS] == APIStatus.ERROR:
-            ODIN_API_LOGGER.error(resp)
+            print('ERROR', resp)
             raise RuntimeError(resp)
-        ODIN_API_LOGGER.info(resp[APIField.RESPONSE])
+        print(resp[APIField.RESPONSE])
 
+def ping_http(url: str) -> None:
+    """Get data for a resource over HTTP
+
+    :param url: The base URL
+    :param resource: The resource ID
+    """
+    try:
+
+        results = HttpClient(url).app_info()
+        print(json.dumps(results))
+    except Exception as e:
+        print('Error pinging server')
+        print(e)
 
 def main():
     """Websocket client for pinging odin."""
@@ -31,14 +44,20 @@ def main():
     parser.add_argument('--port', default=ODIN_PORT)
     parser.add_argument(
         '--scheme',
-        choices={'wss', 'ws'},
+        choices={'wss', 'ws', 'http', 'https'},
         default=ODIN_SCHEME,
-        help='Websocket connection protocol, use `wss` for remote connections and `ws` for localhost',
+        help='Connection protocol, use `http` for REST, use `wss` for remote connections and `ws` for localhost',
     )
-    parser.add_argument('--message', default=datetime.now().strftime("%Y-%m-%dT%H:%M:%S"))
+    args = parser.parse_args()
+    url = f'{args.scheme}://{args.host}:{args.port}'
+
+    if args.scheme.startswith('ws'):
+        asyncio.get_event_loop().run_until_complete(ping(url))
+    else:
+        ping_http(url)
     args = parser.parse_args()
     ws = f'{args.scheme}://{args.host}:{args.port}'
-    asyncio.get_event_loop().run_until_complete(ping(ws, args.message))
+
 
 
 if __name__ == "__main__":

--- a/src/odin-http/main.py
+++ b/src/odin-http/main.py
@@ -19,6 +19,7 @@ from odin.http.orm import *
 from odin.http.utils import (
     _convert_to_path,
     set_repo_creds,
+    _ping_ws_server,
     _request_status,
     _submit_job,
     _request_cleanup,
@@ -217,14 +218,15 @@ def _add_to_job_repo(filename: str, message: str = None) -> str:
 
 
 @app.get("/app")
-def read_main(request: Request):
+async def read_main(request: Request):
+    response = await _ping_ws_server(get_ws_url())
     repo = git.Repo(ODIN_FS_ROOT)
     repo = set_repo_creds(repo)
-
     return {
         "pipelines_root": ODIN_FS_ROOT,
         "pipelines_version": str(git.repo.fun.rev_parse(repo, f'origin/{PIPELINES_MAIN}')),
         "pipelines_repo_dirty": bool(repo.is_dirty()),
+        "ws_server_status": str(response),
     }
 
 

--- a/src/odin-http/main.py
+++ b/src/odin-http/main.py
@@ -1,6 +1,7 @@
 import glob
 import requests
 import time
+import asyncio
 from shutil import copyfile
 import yaml
 from shortid import ShortId
@@ -219,7 +220,10 @@ def _add_to_job_repo(filename: str, message: str = None) -> str:
 
 @app.get("/app")
 async def read_main(request: Request):
-    response = await _ping_ws_server(get_ws_url())
+    try:
+        response = await asyncio.wait_for(_ping_ws_server(get_ws_url()), timeout=3.0)
+    except Exception:
+        response = "unresponsive"
     repo = git.Repo(ODIN_FS_ROOT)
     repo = set_repo_creds(repo)
     return {

--- a/src/odin-http/odin/http/utils.py
+++ b/src/odin-http/odin/http/utils.py
@@ -90,6 +90,20 @@ async def _submit_job(ws, work) -> None:
         return _pipe_id
 
 
+async def _ping_ws_server(uri: str):
+    """Ping odin at uri and send message.
+
+    :param uri: The location of the server
+    :return a status
+    """
+    async with websockets.connect(uri) as websocket:
+        msg = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+        await websocket.send(json.dumps({APIField.COMMAND: 'PING', APIField.REQUEST: msg}))
+        resp = json.loads(await websocket.recv())
+        if resp[APIField.STATUS] == APIStatus.ERROR:
+            return f"unresponsive ({msg})"
+        return f"responsive ({msg})"
+
 async def _request_status(ws, work):
     """Request the status of a job from the server."""
     pipe_statuses = []


### PR DESCRIPTION
The `/app` endpoint for HTTP currently reports the status of the pipeline repo but doesnt try to connect to the WS server.
This adds web-socket proxy to Odin WS.  If the server fails to connect, itll be a 500.  If the server connects, the message
will report:
```
// http://.../v1/app

{
  "pipelines_root": "/data/pipelines",
  "pipelines_version": "3cc76bc2c641d7769d603fa41c5c1fe93430e5b2",
  "pipelines_repo_dirty": true,
  "ws_server_status": "responsive (2022-03-04T12:59:03)"
}
```
If the HTTP server cannot get a response from the WS before a timeout (currently 3s) it will report:

```
// http://.../v1/app

{
  "pipelines_root": "/data/pipelines",
  "pipelines_version": "3cc76bc2c641d7769d603fa41c5c1fe93430e5b2",
  "pipelines_repo_dirty": true,
  "ws_server_status": "unresponsive"
}
```

It also changes the client command `odin-ping` to support (and default to) HTTP.  Under those circumstances it returns the payload of `/v1/app`